### PR TITLE
Add now-required `root-sbd` argument

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,6 +13,7 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/cd.yml@main
     with:
       model: ${{ vars.NAME }}
+      root-sbd: access-esm1p5
     permissions:
       contents: write
     secrets: inherit


### PR DESCRIPTION
Added explicit `root-sbd` argument to ESM1.5 CD as it is required for generating the build metadata. See the linked issue. 

In this PR:
* cd.yml: Added now-required root-sbd argument

References ACCESS-NRI/build-cd#102