### PR TITLE
Update UM versions for runtime orbital parameters

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/2-0-0.json",
+    "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2024.07.10",
-    "spack-config": "2024.07.05"
+    "spack-packages": "2024.07.10"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@
 # configuration settings.
 spack:
   specs:
-    - access-esm1p5@git.2024.05.1
+    - access-esm1p5@git.2024.05.2
   packages:
     # Direct ACCESS-NRI dependencies
     # Note: some packages have branch-specific logic and hence can't use
@@ -18,7 +18,7 @@ spack:
         - '@git.2024.05.21=access-esm1.5'
     um7:
       require:
-        - '@git.2024.07.03=access-esm1.5'
+        - '@git.2024.10.17=access-esm1.5'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -72,9 +72,9 @@ spack:
               'SPACK_{name}_ROOT': '{prefix}'
         projections:
           all: '{name}/{version}'
-          access-esm1p5: '{name}/2024.05.1'
+          access-esm1p5: '{name}/2024.05.2'
           cice4: '{name}/2024.05.21'
-          um7: '{name}/2024.07.03'
+          um7: '{name}/2024.10.17'
           mom5: '{name}/access-esm1.5_2024.08.23'
   config:
     install_tree:


### PR DESCRIPTION
Closes #13.

This pr updates the UM to v 2024.10.17 which allows for orbital parameters to be read from a namelist at runtime. 

Also includes updates to the versions.json file suggested by @CodeGat.