### PR TITLE
Updated `config/versions.json` to `3-0-0`

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,6 +1,5 @@
 {
-    "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/2-0-0.json",
+    "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2024.07.10",
-    "spack-config": "2024.07.05"
+    "spack-packages": "2024.07.10"
 }


### PR DESCRIPTION
In this PR, we update the schema for `ACCESS-ESM1.5`s `config/versions.json` to `3-0-0`. 

## Important

This is an infrastructure update, not a model update. 

This PR does not contain any updates to the model itself, or updates to the versions used. It will fail the usual CI checks because the CI normally expects changes to the model version when it is merged into `main`. 

This PR will be merged using `admin` powers, and there will be no proper deployment when this is merged into `main`. 
