### PR TITLE
Deploy to prerelease with no changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ACCESS-ESM1.5: ACCESS Earth System Model
+# ACCESS-ESM1.5: ACCESS Earth System Model 
 
 ## About the model
 

--- a/spack.yaml
+++ b/spack.yaml
@@ -2,6 +2,7 @@
 #
 # It describes a set of packages to be installed, along with
 # configuration settings.
+# NEW COMMENT
 spack:
   specs:
     - access-esm1p5@git.2024.05.1

--- a/spack.yaml
+++ b/spack.yaml
@@ -5,7 +5,7 @@
 # NEW COMMENT
 spack:
   specs:
-    - access-esm1p5@git.2024.05.1
+    - access-esm1p5@git.2024.05.2
   packages:
     # Direct ACCESS-NRI dependencies
     # Note: some packages have branch-specific logic and hence can't use
@@ -73,7 +73,7 @@ spack:
               'SPACK_{name}_ROOT': '{prefix}'
         projections:
           all: '{name}/{version}'
-          access-esm1p5: '{name}/2024.05.1'
+          access-esm1p5: '{name}/2024.05.2'
           cice4: '{name}/2024.05.21'
           um7: '{name}/2024.07.03'
           mom5: '{name}/access-esm1.5_2024.08.23'


### PR DESCRIPTION
Md5 hashes of the cice and mom executables in #14 did not match the [previous release of ESM1.5 ](https://github.com/ACCESS-NRI/ACCESS-ESM1.5/releases/tag/2024.05.1) despite these not being rebuilt. 

This empty pr has no changes compared to the last release, other than comments, and the updates to the versions.json file in [ee2345b](https://github.com/ACCESS-NRI/ACCESS-ESM1.5/commit/ee2345b33729473804d1c75f022feac3ea541a71)

We'll compare how the executables deployed for this PR against the last release and from #14.