### PR TITLE
Infra Update: `spack.yaml` Simplification, new Projections

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -57,7 +57,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p5: '{name}/2024.05.1-{hash:7}'
+          access-esm1p5: '{name}/2024.05.1'
           cice4: '{name}/2024.05.21-{hash:7}'
           um7: '{name}/2024.07.03-{hash:7}'
           mom5: '{name}/access-esm1.5_2024.08.23-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -50,32 +50,17 @@ spack:
     unify: true
   modules:
     default:
-      enable:
-        - tcl
-      roots:
-        tcl: $spack/../release/modules
-        lmod: $spack/../release/lmod
       tcl:
-        hash_length: 0
         include:
           - access-esm1p5
           - cice4
           - um7
           - mom5
-        exclude_implicits: true
-        all:
-          autoload: run
-          conflict:
-            - '{name}'
-          environment:
-            set:
-              'SPACK_{name}_ROOT': '{prefix}'
         projections:
-          all: '{name}/{version}'
-          access-esm1p5: '{name}/2024.05.1'
-          cice4: '{name}/2024.05.21'
-          um7: '{name}/2024.07.03'
-          mom5: '{name}/access-esm1.5_2024.08.23'
+          access-esm1p5: '{name}/2024.05.1-{hash:7}'
+          cice4: '{name}/2024.05.21-{hash:7}'
+          um7: '{name}/2024.07.03-{hash:7}'
+          mom5: '{name}/access-esm1.5_2024.08.23-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release


### PR DESCRIPTION
> [!NOTE]
> This is an infrastructure update, NOT a proper model update. No release will be created when merging this PR. 

In this PR:
* Simplify `spack.modules` section to not include parts already inherited from `spack-config`
* Update `spack.modules.default.tcl.projections` to have the `-{hash:7}` appended

Closes #17
