### PR TITLE
Include UM runtime orbital parameter changes

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@
 # configuration settings.
 spack:
   specs:
-    - access-esm1p5@git.2024.05.2
+    - access-esm1p5@git.2024.12.0
   packages:
     # Direct ACCESS-NRI dependencies
     # Note: some packages have branch-specific logic and hence can't use
@@ -39,7 +39,6 @@ spack:
     hdf5:
       require:
         - '@1.10.11'
-
     # Preferences for all packages
     all:
       require:
@@ -57,7 +56,7 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p5: '{name}/2024.05.2'
+          access-esm1p5: '{name}/2024.12.0'
           cice4: '{name}/2024.05.21-{hash:7}'
           um7: '{name}/2024.10.17-{hash:7}'
           mom5: '{name}/access-esm1.5_2024.08.23-{hash:7}'
@@ -66,4 +65,4 @@ spack:
       root: $spack/../restricted/ukmo/release
     source_cache: $spack/../restricted/ukmo/source_cache
     build_stage:
-    - $TMPDIR/restricted/spack-stage
+      - $TMPDIR/restricted/spack-stage

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@
 # configuration settings.
 spack:
   specs:
-    - access-esm1p5@git.2024.05.1
+    - access-esm1p5@git.2024.05.2
   packages:
     # Direct ACCESS-NRI dependencies
     # Note: some packages have branch-specific logic and hence can't use
@@ -18,7 +18,7 @@ spack:
         - '@git.2024.05.21=access-esm1.5'
     um7:
       require:
-        - '@git.2024.07.03=access-esm1.5'
+        - '@git.2024.10.17=access-esm1.5'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
@@ -57,9 +57,9 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p5: '{name}/2024.05.1'
+          access-esm1p5: '{name}/2024.05.2'
           cice4: '{name}/2024.05.21-{hash:7}'
-          um7: '{name}/2024.07.03-{hash:7}'
+          um7: '{name}/2024.10.17-{hash:7}'
           mom5: '{name}/access-esm1.5_2024.08.23-{hash:7}'
   config:
     install_tree:


### PR DESCRIPTION
This PR updates the UM version to [`2024.10.17`](https://github.com/ACCESS-NRI/UM7/releases/tag/2024.10.17), which includes the changes from https://github.com/ACCESS-NRI/UM7/pull/16, allowing for orbital parameters to be set at runtime.

---
:rocket: The latest prerelease `access-esm1p5/pr22-5` at d94dacfca807ae8fa73d5e5748aeba8d5ea33d40 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.5/pull/22#issuecomment-2537921370 :rocket:

