### PR TITLE
Test CICE4 dump_last

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
         - '@git.access-esm1.5_2024.08.23=access-esm1.5'
     cice4:
       require:
-        - '@git.2024.05.21=access-esm1.5'
+        - '@git.dump_last_trial=access-esm1.5'
     um7:
       require:
         - '@git.2024.10.17=access-esm1.5'
@@ -57,7 +57,7 @@ spack:
           - mom5
         projections:
           access-esm1p5: '{name}/2024.12.0'
-          cice4: '{name}/2024.05.21-{hash:7}'
+          cice4: '{name}/dump_last_trial-{hash:7}'
           um7: '{name}/2024.10.17-{hash:7}'
           mom5: '{name}/access-esm1.5_2024.08.23-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,7 +1,7 @@
 # This is a Spack Environment file.
 #
 # It describes a set of packages to be installed, along with
-# configuration settings.
+# configuration settings. 
 spack:
   specs:
     - access-esm1p5@git.2024.12.0


### PR DESCRIPTION
Test  adding a `dump_last` namelist option for writing a CICE restart at the end of a simulation

---
:rocket: The latest prerelease `access-esm1p5/pr23-4` at 20286f4f84913fdf70cad150cbea4b35b01a50b0 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.5/pull/23#issuecomment-2578815941 :rocket:



