### PR TITLE
Test mom5 fix for oneapi

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -12,10 +12,10 @@ spack:
     # requiring a `@git.DATE=BRANCH` version.
     mom5:
       require:
-        - '@git.access-esm1.5_2024.08.23=access-esm1.5'
+        - '@git.access-esm1.5-2025.03.001=access-esm1.5'
     cice4:
       require:
-        - '@git.2024.05.21=access-esm1.5'
+        - '@git.access-esm1.5-2025.03.001=access-esm1.5'
     um7:
       require:
         - '@git.2024.10.17=access-esm1.5'
@@ -25,7 +25,7 @@ spack:
         - '@git.2024.05.28=access-esm1.5'
     oasis3-mct:
       require:
-        - '@git.access-esm1.5_2024.05.24=access-esm1.5'
+        - '@git.access-esm1.5-2025.03.001=access-esm1.5'
     # Other dependencies
     openmpi:
       require:
@@ -57,9 +57,9 @@ spack:
           - mom5
         projections:
           access-esm1p5: '{name}/2024.12.0'
-          cice4: '{name}/2024.05.21-{hash:7}'
+          cice4: '{name}/access-esm1.5-2025.03.001-{hash:7}'
           um7: '{name}/2024.10.17-{hash:7}'
-          mom5: '{name}/access-esm1.5_2024.08.23-{hash:7}'
+          mom5: '{name}/access-esm1.5-2025.03.001-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release


### PR DESCRIPTION


---
:rocket: The latest prerelease `access-esm1p5/pr26-3` at 1d61fa1d50a191ef57d46bbebb3a448807adad4a is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.5/pull/26#issuecomment-2697074661 :rocket:




