### PR TITLE
Test version removal from dependencies

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2024.07.10"
+    "spack-packages": "remove-versions-from-esm-dependencies"
 }


### PR DESCRIPTION


---
:rocket: The latest prerelease `access-esm1p5/pr28-1` at 460c3ff1422e2431d7e7229d124bb29287311519 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.5/pull/28#issuecomment-2697340782 :rocket:
