### PR TITLE
Use MOM5 version that limits temp in Schmidt number calculation

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -12,7 +12,7 @@ spack:
     # requiring a `@git.DATE=BRANCH` version.
     mom5:
       require:
-        - '@git.access-esm1.5_2024.08.23=access-esm1.5'
+        - '@git.9c3226feb54f4ec2a3bc14515c9668f967318a81=access-esm1.5' # On access-esm1.5-WOMBAT-limit-schmidt
     cice4:
       require:
         - '@git.2024.05.21=access-esm1.5'
@@ -59,7 +59,7 @@ spack:
           access-esm1p5: '{name}/2024.12.0'
           cice4: '{name}/2024.05.21-{hash:7}'
           um7: '{name}/2024.10.17-{hash:7}'
-          mom5: '{name}/access-esm1.5_2024.08.23-{hash:7}'
+          mom5: '{name}/9c3226feb54f4ec2a3bc14515c9668f967318a81-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release


### PR DESCRIPTION
This PR is to build a prerelease that includes, in WOMBAT, temperature limiting in the calculation of Schmidt numbers.

For motivation, see https://forum.access-hive.org.au/t/wombat-crashing-in-miocene-access-esm1-5-simulation/4344

---
:rocket: The latest prerelease `access-esm1p5/pr29-1` at 161ff11c7dcd3c267f4c6d7e5841d21c524325a4 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.5/pull/29#issuecomment-2749739990 :rocket:
