### PR TITLE
Release access-esm1p5 2024.12.1

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.03.005"
+    "spack-packages": "2025.03.006"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2024.07.10"
+    "spack-packages": "2025.03.005"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
         - '@git.access-esm1.5-2025.03.002=access-esm1.5'
     cice4:
       require:
-        - '@git.2024.05.21=access-esm1.5'
+        - '@git.access-esm1.5-2025.04.001=access-esm1.5'
     um7:
       require:
         - '@git.2024.10.17=access-esm1.5'
@@ -57,7 +57,7 @@ spack:
           - mom5
         projections:
           access-esm1p5: '{name}/2024.12.1'
-          cice4: '{name}/2024.05.21-{hash:7}'
+          cice4: '{name}/access-esm1.5-2025.04.001-{hash:7}'
           um7: '{name}/2024.10.17-{hash:7}'
           mom5: '{name}/access-esm1.5-2025.03.002-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@
 # configuration settings.
 spack:
   specs:
-    - access-esm1p5@git.2024.12.0
+    - access-esm1p5@git.2024.12.1
   packages:
     # Direct ACCESS-NRI dependencies
     # Note: some packages have branch-specific logic and hence can't use
@@ -12,7 +12,7 @@ spack:
     # requiring a `@git.DATE=BRANCH` version.
     mom5:
       require:
-        - '@git.access-esm1.5_2024.08.23=access-esm1.5'
+        - '@git.access-esm1.5-2025.03.002=access-esm1.5'
     cice4:
       require:
         - '@git.2024.05.21=access-esm1.5'
@@ -56,10 +56,10 @@ spack:
           - um7
           - mom5
         projections:
-          access-esm1p5: '{name}/2024.12.0'
+          access-esm1p5: '{name}/2024.12.1'
           cice4: '{name}/2024.05.21-{hash:7}'
           um7: '{name}/2024.10.17-{hash:7}'
-          mom5: '{name}/access-esm1.5_2024.08.23-{hash:7}'
+          mom5: '{name}/access-esm1.5-2025.03.002-{hash:7}'
   config:
     install_tree:
       root: $spack/../restricted/ukmo/release


### PR DESCRIPTION
This release:
- [x] Updates MOM5 to [access-esm1.5-2025.03.002](https://github.com/ACCESS-NRI/MOM5/releases/tag/access-esm1.5-2025.03.002), which includes
  - WOMBAT fix to prevent negative Schmidt numbers in warm temperatures (https://github.com/ACCESS-NRI/MOM5/pull/36)
  - Updates for oneapi (https://github.com/ACCESS-NRI/MOM5/pull/32)
- [x] Updates `spack-packages` to [2025.03.006](https://github.com/ACCESS-NRI/spack-packages/releases/tag/2025.03.006)
- [x] Updates CICE4 to [access-esm1.5-2025.04.001](https://github.com/ACCESS-NRI/cice4/releases/tag/access-esm1.5-2025.04.001) which includes
  -  CICE error reporting changes so that error messages are written to stderr, and non-zero exit codes are used (https://github.com/ACCESS-NRI/cice4/pull/14)

Closes #30
Closes #34 

---
:rocket: The latest prerelease `access-esm1p5/pr31-4` at 2bae283014b6bb25437ad669445960b2a45fca10 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.5/pull/31#issuecomment-2785200088 :rocket:
