### PR TITLE
test CICE error reporting changes

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "1a277ef57cbdc03346564c82b24e825ca557eb7c"
+    "spack-packages": "2024.07.10"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2024.07.10"
+    "spack-packages": "1a277ef57cbdc03346564c82b24e825ca557eb7c"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "1a277ef57cbdc03346564c82b24e825ca557eb7c"
+    "spack-packages": "cd74f817ef3c4588a585d985be3c99ea7ff261ea"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2024.07.10"
+    "spack-packages": "cd74f817ef3c4588a585d985be3c99ea7ff261ea"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "cd74f817ef3c4588a585d985be3c99ea7ff261ea"
+    "spack-packages": "1a277ef57cbdc03346564c82b24e825ca557eb7c"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
         - '@git.access-esm1.5_2024.08.23=access-esm1.5'
     cice4:
       require:
-        - '@git.5e3dc23f3cf715909cc3305198ac819851cf2b0e=access-esm1.5'
+        - '@git.e0d92075330af3a45f97914a81985e4178fc3857=access-esm1.5'
     um7:
       require:
         - '@git.2024.10.17=access-esm1.5'
@@ -57,7 +57,7 @@ spack:
           - mom5
         projections:
           access-esm1p5: '{name}/2024.12.0'
-          cice4: '{name}/5e3dc23f3cf715909cc3305198ac819851cf2b0e-{hash:7}'
+          cice4: '{name}/e0d92075330af3a45f97914a81985e4178fc3857-{hash:7}'
           um7: '{name}/2024.10.17-{hash:7}'
           mom5: '{name}/access-esm1.5_2024.08.23-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
         - '@git.access-esm1.5_2024.08.23=access-esm1.5'
     cice4:
       require:
-        - '@git.55ecae94d3a2874f4d92922da3e24fdea3527b61=access-esm1.5'
+        - '@git.5f13243dc76e4b0e108ea642f2933ad29ca9ae48=access-esm1.5'
     um7:
       require:
         - '@git.2024.10.17=access-esm1.5'
@@ -57,7 +57,7 @@ spack:
           - mom5
         projections:
           access-esm1p5: '{name}/2024.12.0'
-          cice4: '{name}/55ecae94d3a2874f4d92922da3e24fdea3527b61-{hash:7}'
+          cice4: '{name}/5f13243dc76e4b0e108ea642f2933ad29ca9ae48-{hash:7}'
           um7: '{name}/2024.10.17-{hash:7}'
           mom5: '{name}/access-esm1.5_2024.08.23-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
         - '@git.access-esm1.5_2024.08.23=access-esm1.5'
     cice4:
       require:
-        - '@git.a3b1cc1e0261936f7c50f90f1e440e65ade77911=access-esm1.5'
+        - '@git.4a180884aee5e0c3dfb20cbf26a32abeb8e4a2d8=access-esm1.5'
     um7:
       require:
         - '@git.2024.10.17=access-esm1.5'
@@ -57,7 +57,7 @@ spack:
           - mom5
         projections:
           access-esm1p5: '{name}/2024.12.0'
-          cice4: '{name}/a3b1cc1e0261936f7c50f90f1e440e65ade77911-{hash:7}'
+          cice4: '{name}/4a180884aee5e0c3dfb20cbf26a32abeb8e4a2d8-{hash:7}'
           um7: '{name}/2024.10.17-{hash:7}'
           mom5: '{name}/access-esm1.5_2024.08.23-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
         - '@git.access-esm1.5_2024.08.23=access-esm1.5'
     cice4:
       require:
-        - '@git.5f13243dc76e4b0e108ea642f2933ad29ca9ae48=access-esm1.5'
+        - '@git.68c6404291d462accb4a622233e336af19f0e922=access-esm1.5'
     um7:
       require:
         - '@git.2024.10.17=access-esm1.5'
@@ -57,7 +57,7 @@ spack:
           - mom5
         projections:
           access-esm1p5: '{name}/2024.12.0'
-          cice4: '{name}/5f13243dc76e4b0e108ea642f2933ad29ca9ae48-{hash:7}'
+          cice4: '{name}/68c6404291d462accb4a622233e336af19f0e922-{hash:7}'
           um7: '{name}/2024.10.17-{hash:7}'
           mom5: '{name}/access-esm1.5_2024.08.23-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,6 +16,7 @@ spack:
     cice4:
       require:
         - '@git.01a5443de31a12f1f32c9410174a17232eb88155=access-esm1.5'
+        - fflags='-cpp'
     um7:
       require:
         - '@git.2024.10.17=access-esm1.5'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
         - '@git.access-esm1.5_2024.08.23=access-esm1.5'
     cice4:
       require:
-        - '@git.2024.05.21=access-esm1.5'
+        - '@git.a3b1cc1e0261936f7c50f90f1e440e65ade77911=access-esm1.5'
     um7:
       require:
         - '@git.2024.10.17=access-esm1.5'
@@ -57,7 +57,7 @@ spack:
           - mom5
         projections:
           access-esm1p5: '{name}/2024.12.0'
-          cice4: '{name}/2024.05.21-{hash:7}'
+          cice4: '{name}/a3b1cc1e0261936f7c50f90f1e440e65ade77911-{hash:7}'
           um7: '{name}/2024.10.17-{hash:7}'
           mom5: '{name}/access-esm1.5_2024.08.23-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
         - '@git.access-esm1.5_2024.08.23=access-esm1.5'
     cice4:
       require:
-        - '@git.af5d21acec06291b8225b6294eb9b026cdf9eec8=access-esm1.5'
+        - '@git.01a5443de31a12f1f32c9410174a17232eb88155=access-esm1.5'
     um7:
       require:
         - '@git.2024.10.17=access-esm1.5'
@@ -57,7 +57,7 @@ spack:
           - mom5
         projections:
           access-esm1p5: '{name}/2024.12.0'
-          cice4: '{name}/af5d21acec06291b8225b6294eb9b026cdf9eec8-{hash:7}'
+          cice4: '{name}/01a5443de31a12f1f32c9410174a17232eb88155-{hash:7}'
           um7: '{name}/2024.10.17-{hash:7}'
           mom5: '{name}/access-esm1.5_2024.08.23-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
         - '@git.access-esm1.5_2024.08.23=access-esm1.5'
     cice4:
       require:
-        - '@git.e0d92075330af3a45f97914a81985e4178fc3857=access-esm1.5'
+        - '@git.e9e514e19d82216d5091fda3f6f3aeeaeba6e085=access-esm1.5'
     um7:
       require:
         - '@git.2024.10.17=access-esm1.5'
@@ -57,7 +57,7 @@ spack:
           - mom5
         projections:
           access-esm1p5: '{name}/2024.12.0'
-          cice4: '{name}/e0d92075330af3a45f97914a81985e4178fc3857-{hash:7}'
+          cice4: '{name}/e9e514e19d82216d5091fda3f6f3aeeaeba6e085-{hash:7}'
           um7: '{name}/2024.10.17-{hash:7}'
           mom5: '{name}/access-esm1.5_2024.08.23-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
         - '@git.access-esm1.5_2024.08.23=access-esm1.5'
     cice4:
       require:
-        - '@git.4a180884aee5e0c3dfb20cbf26a32abeb8e4a2d8=access-esm1.5'
+        - '@git.ab55a272c0414c9e94b0b774f4e1a740afe7248f=access-esm1.5'
     um7:
       require:
         - '@git.2024.10.17=access-esm1.5'
@@ -57,7 +57,7 @@ spack:
           - mom5
         projections:
           access-esm1p5: '{name}/2024.12.0'
-          cice4: '{name}/4a180884aee5e0c3dfb20cbf26a32abeb8e4a2d8-{hash:7}'
+          cice4: '{name}/ab55a272c0414c9e94b0b774f4e1a740afe7248f-{hash:7}'
           um7: '{name}/2024.10.17-{hash:7}'
           mom5: '{name}/access-esm1.5_2024.08.23-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
         - '@git.access-esm1.5_2024.08.23=access-esm1.5'
     cice4:
       require:
-        - '@git.e9e514e19d82216d5091fda3f6f3aeeaeba6e085=access-esm1.5'
+        - '@git.9150abe4f636c51a4444a5b30494f4543e976175=access-esm1.5'
     um7:
       require:
         - '@git.2024.10.17=access-esm1.5'
@@ -57,7 +57,7 @@ spack:
           - mom5
         projections:
           access-esm1p5: '{name}/2024.12.0'
-          cice4: '{name}/e9e514e19d82216d5091fda3f6f3aeeaeba6e085-{hash:7}'
+          cice4: '{name}/9150abe4f636c51a4444a5b30494f4543e976175-{hash:7}'
           um7: '{name}/2024.10.17-{hash:7}'
           mom5: '{name}/access-esm1.5_2024.08.23-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -16,7 +16,7 @@ spack:
     cice4:
       require:
         - '@git.01a5443de31a12f1f32c9410174a17232eb88155=access-esm1.5'
-        - fflags='-cpp'
+        - 'fflags="-cpp"'
     um7:
       require:
         - '@git.2024.10.17=access-esm1.5'

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
         - '@git.access-esm1.5_2024.08.23=access-esm1.5'
     cice4:
       require:
-        - '@git.9150abe4f636c51a4444a5b30494f4543e976175=access-esm1.5'
+        - '@git.af5d21acec06291b8225b6294eb9b026cdf9eec8=access-esm1.5'
     um7:
       require:
         - '@git.2024.10.17=access-esm1.5'
@@ -57,7 +57,7 @@ spack:
           - mom5
         projections:
           access-esm1p5: '{name}/2024.12.0'
-          cice4: '{name}/9150abe4f636c51a4444a5b30494f4543e976175-{hash:7}'
+          cice4: '{name}/af5d21acec06291b8225b6294eb9b026cdf9eec8-{hash:7}'
           um7: '{name}/2024.10.17-{hash:7}'
           mom5: '{name}/access-esm1.5_2024.08.23-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,8 +15,7 @@ spack:
         - '@git.access-esm1.5_2024.08.23=access-esm1.5'
     cice4:
       require:
-        - '@git.01a5443de31a12f1f32c9410174a17232eb88155=access-esm1.5'
-        - 'fflags="-cpp"'
+        - '@git.55ecae94d3a2874f4d92922da3e24fdea3527b61=access-esm1.5'
     um7:
       require:
         - '@git.2024.10.17=access-esm1.5'
@@ -58,7 +57,7 @@ spack:
           - mom5
         projections:
           access-esm1p5: '{name}/2024.12.0'
-          cice4: '{name}/01a5443de31a12f1f32c9410174a17232eb88155-{hash:7}'
+          cice4: '{name}/55ecae94d3a2874f4d92922da3e24fdea3527b61-{hash:7}'
           um7: '{name}/2024.10.17-{hash:7}'
           mom5: '{name}/access-esm1.5_2024.08.23-{hash:7}'
   config:

--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
         - '@git.access-esm1.5_2024.08.23=access-esm1.5'
     cice4:
       require:
-        - '@git.ab55a272c0414c9e94b0b774f4e1a740afe7248f=access-esm1.5'
+        - '@git.5e3dc23f3cf715909cc3305198ac819851cf2b0e=access-esm1.5'
     um7:
       require:
         - '@git.2024.10.17=access-esm1.5'
@@ -57,7 +57,7 @@ spack:
           - mom5
         projections:
           access-esm1p5: '{name}/2024.12.0'
-          cice4: '{name}/ab55a272c0414c9e94b0b774f4e1a740afe7248f-{hash:7}'
+          cice4: '{name}/5e3dc23f3cf715909cc3305198ac819851cf2b0e-{hash:7}'
           um7: '{name}/2024.10.17-{hash:7}'
           mom5: '{name}/access-esm1.5_2024.08.23-{hash:7}'
   config:


### PR DESCRIPTION
Build to test updates to CICE4's error reporting 

---
:rocket: The latest prerelease `access-esm1p5/pr32-27` at 9b70433efa9d4b2660081e65330f1d233f5c3e61 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.5/pull/32#issuecomment-2774624094 :rocket:


























