### PR TITLE
Test MOM5 spack-package changes

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "dev-2025.04.001"
+    "spack-packages": "dev-2025.04.004"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.03.006"
+    "spack-packages": "dev-2025.04.001"
 }


### PR DESCRIPTION
This is a draft PR to create a prerelease of ACCESS-ESM1.5 using the changes to the MOM5 SPR in https://github.com/ACCESS-NRI/spack-packages/pull/227

---
:rocket: The latest prerelease `access-esm1p5/pr35-3` at 1a748514e6f2a3bdddf4d305b851e727957ccf09 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.5/pull/35#issuecomment-2823175240 :rocket:




