### PR TITLE
Testing with MOM5 CMake support

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "e7c653bd3b2ef11d719f2f22dd1582ebb3a55d6a"
+    "spack-packages": "ed25bd497a716cc4edaa867cc14e06dbc3777149"
 }


### PR DESCRIPTION
This PR is to create prereleases to test the new MOM5 SPR that supports the new CMake build system - see https://github.com/ACCESS-NRI/spack-packages/pull/238.

---
:rocket: The latest prerelease `access-esm1p5/pr37-4` at 6a583e2b91d86dbf4a929e65367fc63c58064180 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.5/pull/37#issuecomment-2903350723 :rocket:



