### PR TITLE
TEST: Projection Injection on Existing Projections

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v5
+    uses: access-nri/build-cd/.github/workflows/cd.yml@169-inject-projections_TEST
     with:
       model: ${{ vars.NAME }}
       root-sbd: access-esm1p5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     if: >-
       (github.event_name == 'pull_request' && github.event.action != 'closed') ||
       (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!redeploy'))
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v5
+    uses: access-nri/build-cd/.github/workflows/ci.yml@169-inject-projections_TEST
     with:
       model: ${{ vars.NAME }}
       root-sbd: access-esm1p5
@@ -39,7 +39,7 @@ jobs:
   pr-comment:
     name: Comment
     if: github.event_name == 'issue_comment'
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v5
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@169-inject-projections_TEST
     with:
       model: ${{ vars.NAME }}
       root-sbd: access-esm1p5
@@ -51,7 +51,7 @@ jobs:
   pr-closed:
     name: Closed
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v5
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@169-inject-projections_TEST
     with:
       root-sbd: access-esm1p5
     secrets: inherit

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,4 +1,4 @@
-# This is a Spack Environment file.
+# This is a Spack Environment file!
 #
 # It describes a set of packages to be installed, along with
 # configuration settings.


### PR DESCRIPTION
> [!IMPORTANT]
> This is a test of a future update to `build-cd` infrastructure and will not be merged. 

References ACCESS-NRI/build-cd#295

## Background

Having to edit versions in multiple places has been a sore spot for users and infra maintainers for a bit, so I'm testing injecting projections. 

One of the tests is injecting projections with all the required ones defined already. 


---
:rocket: The latest prerelease `access-esm1p5/pr38-1` at eeab2fff85a0c72f82da5a3ef12c78b6cb9c6a25 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.5/pull/38#issuecomment-3054818256 :rocket:
