### PR TITLE
Build ESM1.5 using oneAPI 2025.2.0 and openmpi 5.0.8

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
     "spack": "0.22",
-    "spack-packages": "2025.03.006"
+    "spack-packages": "2025.09.001"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@
 # configuration settings.
 spack:
   specs:
-    - access-esm1p5@git.2024.12.1
+    - access-esm1p5@git.2025.09.000
   packages:
     # Direct ACCESS-NRI dependencies
     # Note: some packages have branch-specific logic and hence can't use
@@ -22,27 +22,34 @@ spack:
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
-        - '@git.2024.05.28=access-esm1.5'
+        - '@git.2025.08.000=access-esm1.5'
     oasis3-mct:
       require:
-        - '@git.access-esm1.5_2024.05.24=access-esm1.5'
+        - '@git.access-esm1.5-2025.03.001=access-esm1.5'
     # Other dependencies
     openmpi:
       require:
-        - '@4.0.2'
+        - '@5.0.8'
     netcdf-c:
       require:
-        - '@4.7.4'
+        - '@4.9.2'
     netcdf-fortran:
       require:
-        - '@4.5.2'
+        - '@4.6.1'
     hdf5:
       require:
-        - '@1.10.11'
+        - '@1.14.3'
+    gcc-runtime:
+      require:
+        - '%gcc'
+    glibc:
+      require:
+        - '@2.28'
+        - '%gcc'
     # Preferences for all packages
     all:
       require:
-        - '%intel@19.0.3.199'
+        - '%oneapi@2025.2.0'
         - 'target=x86_64_v4'
   view: true
   concretizer:


### PR DESCRIPTION
Changes based on https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/126