### PR TITLE
Infra Update `v8`: `spack v1` Support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,12 +10,12 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v7
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v8
     with:
       model: ${{ vars.NAME }}
       root-sbd: access-esm1p5
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       contents: write

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,7 +13,6 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/cd.yml@v8
     with:
       model: ${{ vars.NAME }}
-      root-sbd: access-esm1p5
       spack-manifest-schema-version: 2-0-0
       config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -8,14 +8,12 @@ jobs:
   redeploy:
     name: Redeploy
     if: startsWith(github.event.comment.body, '!redeploy') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
-      pr: ${{ github.event.issue.number }}
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
-      root-sbd: access-esm1p5
     permissions:
       pull-requests: write
       contents: write
@@ -24,10 +22,9 @@ jobs:
   bump:
     name: Bump
     if: startsWith(github.event.comment.body, '!bump') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v8
     with:
       model: ${{ vars.NAME }}
-      root-sbd: access-esm1p5
     permissions:
       pull-requests: write
       contents: write
@@ -35,11 +32,10 @@ jobs:
   configs:
     name: Configs
     if: startsWith(github.event.comment.body, '!update-configs') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v8
     with:
       model: ${{ vars.NAME }}
       auto-configs-pr-schema-version: 1-0-0
-      root-sbd: access-esm1p5
     permissions:
       pull-requests: write
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,14 @@ on:
 jobs:
   pr-ci:
     name: CI
-    if: >-
-      github.event.action != 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
+    if: github.event.action != 'closed'
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
       root-sbd: access-esm1p5
       pr: ${{ github.event.pull_request.number }}
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       pull-requests: write
@@ -36,7 +35,7 @@ jobs:
   pr-closed:
     name: Closed
     if: github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
     with:
       root-sbd: access-esm1p5
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
-      root-sbd: access-esm1p5
-      pr: ${{ github.event.pull_request.number }}
       spack-manifest-schema-version: 2-0-0
       config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
@@ -36,6 +34,4 @@ jobs:
     name: Closed
     if: github.event.action == 'closed'
     uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
-    with:
-      root-sbd: access-esm1p5
     secrets: inherit

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
-  "spack": "1.0",
+  "spack": "1.1",
   "access-spack-packages": "2025.03.006"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2025.03.006",
-  "custom-scopes": ["ukmo-restricted-scope"]
+  "access-spack-packages": "2026.02.002",
+  "custom-scopes": [
+    "ukmo-restricted-scope"
+  ]
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
-    "spack": "0.22",
-    "spack-packages": "2025.03.006"
+  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
+  "spack": "1.0",
+  "access-spack-packages": "2025.03.006"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2025.03.006"
+  "access-spack-packages": "2025.03.006",
+  "custom-scopes": ["ukmo-restricted-scope"]
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -51,9 +51,3 @@ spack:
   view: true
   concretizer:
     unify: true
-  config:
-    install_tree:
-      root: $spack/../restricted/ukmo/release
-    source_cache: $spack/../restricted/ukmo/source_cache
-    build_stage:
-    - $TMPDIR/restricted/spack-stage

--- a/spack.yaml
+++ b/spack.yaml
@@ -56,7 +56,7 @@ spack:
 
     # Preferences for all packages
     all:
-      require:
+      prefer:
       - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -44,13 +44,19 @@ spack:
       require:
       - '@1.10.11'
     # Compilers
-    intel-oneapi-compilers-classic:
+    c:
       require:
-      - '@19.0.3.199'
+      - intel-oneapi-compilers-classic@19.0.3.199
+    cxx:
+      require:
+      - intel-oneapi-compilers-classic@19.0.3.199
+    fortran:
+      require:
+      - intel-oneapi-compilers-classic@19.0.3.199
+
     # Preferences for all packages
     all:
       require:
-      - '%access_intel'
       - 'target=x86_64_v4'
   view: true
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -3,8 +3,12 @@
 # It describes a set of packages to be installed, along with
 # configuration settings.
 spack:
+  definitions:
+  # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
+  - _name: [access-esm1p5]
+  - _version: [2024.12.1]
   specs:
-  - access-esm1p5@git.2024.12.1
+  - access-esm1p5
   packages:
     # Direct ACCESS-NRI dependencies
     # Note: some packages have branch-specific logic and hence can't use

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@
 # configuration settings.
 spack:
   specs:
-    - access-esm1p5@git.2024.12.1
+  - access-esm1p5@git.2024.12.1
   packages:
     # Direct ACCESS-NRI dependencies
     # Note: some packages have branch-specific logic and hence can't use
@@ -12,38 +12,38 @@ spack:
     # requiring a `@git.DATE=BRANCH` version.
     mom5:
       require:
-        - '@git.access-esm1.5-2025.03.002=access-esm1.5'
+      - '@git.access-esm1.5-2025.03.002=access-esm1.5'
     cice4:
       require:
-        - '@git.access-esm1.5-2025.04.001=access-esm1.5'
+      - '@git.access-esm1.5-2025.04.001=access-esm1.5'
     um7:
       require:
-        - '@git.2024.10.17=access-esm1.5'
+      - '@git.2024.10.17=access-esm1.5'
     # Lower-level ACCESS-NRI dependencies
     gcom4:
       require:
-        - '@git.2024.05.28=access-esm1.5'
+      - '@git.2024.05.28=access-esm1.5'
     oasis3-mct:
       require:
-        - '@git.access-esm1.5_2024.05.24=access-esm1.5'
+      - '@git.access-esm1.5_2024.05.24=access-esm1.5'
     # Other dependencies
     openmpi:
       require:
-        - '@4.0.2'
+      - '@4.0.2'
     netcdf-c:
       require:
-        - '@4.7.4'
+      - '@4.7.4'
     netcdf-fortran:
       require:
-        - '@4.5.2'
+      - '@4.5.2'
     hdf5:
       require:
-        - '@1.10.11'
+      - '@1.10.11'
     # Preferences for all packages
     all:
       require:
-        - '%intel@19.0.3.199'
-        - 'target=x86_64_v4'
+      - '%intel@19.0.3.199'
+      - 'target=x86_64_v4'
   view: true
   concretizer:
     unify: true
@@ -52,4 +52,4 @@ spack:
       root: $spack/../restricted/ukmo/release
     source_cache: $spack/../restricted/ukmo/source_cache
     build_stage:
-      - $TMPDIR/restricted/spack-stage
+    - $TMPDIR/restricted/spack-stage

--- a/spack.yaml
+++ b/spack.yaml
@@ -43,10 +43,14 @@ spack:
     hdf5:
       require:
       - '@1.10.11'
+    # Compilers
+    intel-oneapi-compilers-classic:
+      require:
+      - '@19.0.3.199'
     # Preferences for all packages
     all:
       require:
-      - '%intel@19.0.3.199'
+      - '%access_intel'
       - 'target=x86_64_v4'
   view: true
   concretizer:


### PR DESCRIPTION
References issue ACCESS-NRI/build-cd#313 and PR ACCESS-NRI/build-cd#326
References rollout issue ACCESS-NRI/build-cd#328
References project https://github.com/orgs/ACCESS-NRI/projects/37

> [!NOTE]
> This infra update breaks reproducibility with the latest release (https://github.com/ACCESS-NRI/ACCESS-ESM1.5/releases/tag/2024.12.1). It will be merged without a release, so future PRs will need to keep this in mind. 

> [!IMPORTANT]
> This PR is a major update to the deployment infrastructure. See below for the prerequisites for this repository to be able to merge this PR.

> [!IMPORTANT]
> This major version change marks the end of major infrastructure updates for deployments to `spack < 1.0`.
> If you want to deploy to instances of `spack < 1.0`, you must use `build-cd < v8`.
> If you want to deploy to instances of `spack >= 1.0`, you must use `build-cd >= v8`.

## Background

We are moving on up to `spack v1`! This update to spack contains many bug fixes, optimisations and new features that can be incorporated into `build-cd`.

This update also contains changes that make `spack v0.X` incompatible with this `build-cd v8` update - the most prominent one being the splitting of spacks core codebase from it's builtin spack-packages repo. This means that for provenance, one to keep track of both `builtin` spack-packages and our own, renamed `access-spack-packages`. `build-cd` will centrally control the version of builtin `spack-packages` for a given instance, and `config/versions.json`s `spack-packages` key is renamed to `access-spack-packages`.

As noted earlier, this major version of `build-cd` can only support `spack v1`, due to `spack v1`-specific commands in the infrastructure. If you still want to deploy to `spack v0.X`, you will need to change `build-cd` to `v7`, and update the `config/versions.json` file/`spack.yaml`.

## Features

* **Support for spack v1**: We're moving to a new, non-beta version of spack! It contains bug fixes, features and optimisations over the old version.

## Prerequisites for Merging

- [x] Update `build-cd` entrypoints (this PR!)
- [x] Update `config/versions.json` with new inputs (also this PR!)
- [x] Validate compiler additions to the spack manifest (this PR, too!)
- [x] Test and Verify Model built with `spack v1`


---
:rocket: The latest prerelease `access-esm1p5/pr46-3` at 8a613a7459429fc5b06f0fc52f099ea56396e9d1 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.5/pull/46#issuecomment-3988023457 :rocket:


