### PR TITLE
Update versions.json

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.02.002",
+  "access-spack-packages": "446",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]


### PR DESCRIPTION
Test for https://github.com/ACCESS-NRI/access-spack-packages/pull/447

---
:rocket: The latest prerelease `access-esm1p5/pr50-1` at da8d66bc13d84e05b8d01dc2015a73b5dbd2af91 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.5/pull/50#issuecomment-4786520226 :rocket:
