### PR TITLE
Test access-spack-packages branch `cleanup-before-esm1.6-release`

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.02.002",
+  "access-spack-packages": "e8ed648739ad761f3fef29dd7535d4168beb3f0d",
   "custom-scopes": [
     "ukmo-restricted-scope"
   ]


### PR DESCRIPTION
This PR is to test the proposed changes to `access-spack-packages` in [this PR](https://github.com/ACCESS-NRI/access-spack-packages/pull/443), which:

- removes support for ACCESS-ESM1.5
- removes makefile support from the mom5 SPR
- moves mom5, access_fms, libaccessom2 to numerical versioning

---
:rocket: The latest prerelease `access-esm1p5/pr54-1` at 793b5446b369ee47f40c17acac7a201354274ec7 is here: https://github.com/ACCESS-NRI/ACCESS-ESM1.5/pull/54#issuecomment-5126293431 :rocket:
